### PR TITLE
Bump solr heap size as we kept running into OOME during reindex

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         ports:
             - "${SOLR_PORT}:8983"            
         command: solr -f -cloud
+        environment:
+            - SOLR_HEAP=1024m
         
     isamples_inabox:
         build:


### PR DESCRIPTION
@datadavev When it rains, it pours.  Reindex job crashed solr -- doubling the heap size if that fixes it.