### PR TITLE
move datacite credentials to secrets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
         secrets:
             - orcid_client_id
             - orcid_client_secret
+            - datacite_username
+            - datacite_password
 
 
     solr_schema_init:
@@ -65,3 +67,7 @@ secrets:
         file: ./secrets/orcid_client_id
     orcid_client_secret:
         file: ./secrets/orcid_client_secret
+    datacite_username:
+        file: ./secrets/datacite_username
+    datacite_password:
+        file: ./secrets/datacite_password

--- a/isb/isb_container_startup.sh
+++ b/isb/isb_container_startup.sh
@@ -3,6 +3,8 @@
 # export secrets as env vars
 export ORCID_CLIENT_ID=`cat /run/secrets/orcid_client_id`
 export ORCID_CLIENT_SECRET=`cat /run/secrets/orcid_client_secret`
+export DATACITE_USERNAME=`cat /run/secrets/datacite_username`
+export DATACITE_PASSWORD=`cat /run/secrets/datacite_password`
 # Note that cron jobs don't inherit the environment when run -- docker *does* run with environment variables 
 # so we need this step to export the docker environment for cron
 declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /container.env


### PR DESCRIPTION
Similar to what we did with orcid -- move these to hand-edited files outside of git