### PR TITLE
Datacite prefix

### DIFF
--- a/.env.mars
+++ b/.env.mars
@@ -9,3 +9,4 @@ ISB_HOST=mars.cyverse.org
 ENV_FILE=mars.isb_web_config.env
 ANALYTICS_DOMAIN=isamples.org
 ORCID_TOKEN_REDIRECT_URI="https://mars.cyverse.org/isamples_central/orcid_token"
+DATACITE_PREFIX="10.82273"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
                 ENV_FILE: ${ENV_FILE}
                 ISB_SITEMAP_PREFIX: https://${ISB_HOST}/${UVICORN_ROOT_PATH}
                 ANALYTICS_DOMAIN: ${ANALYTICS_DOMAIN}
+                DATACITE_PREFIX: ${DATACITE_PREFIX}
                 
         ports:
             # In the Docker network, start on 8000 and map that to the external port specified in the environment file

--- a/isb/Dockerfile
+++ b/isb/Dockerfile
@@ -47,7 +47,7 @@ COPY ./isamples_webui/index.html /app/isb_web/ui/
 COPY ./isamples_webui/manifest.json /app/isb_web/ui/
 COPY ./isamples_webui/robots.txt /app/isb_web/ui/
 COPY ./isamples_webui/static /app/isb_web/ui/static
-RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\"\n, \"datacite_prefix\": \"$DATACITE_PREFIX\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
+RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\",\n \"datacite_prefix\": \"$DATACITE_PREFIX\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
 
 # Install nodejs in the container
 USER root

--- a/isb/Dockerfile
+++ b/isb/Dockerfile
@@ -47,7 +47,7 @@ COPY ./isamples_webui/index.html /app/isb_web/ui/
 COPY ./isamples_webui/manifest.json /app/isb_web/ui/
 COPY ./isamples_webui/robots.txt /app/isb_web/ui/
 COPY ./isamples_webui/static /app/isb_web/ui/static
-RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\",\n \"datacite_prefix\": \"$DATACITE_PREFIX\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
+RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\",\n  \"datacite_prefix\": \"$DATACITE_PREFIX\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
 
 # Install nodejs in the container
 USER root

--- a/isb/Dockerfile
+++ b/isb/Dockerfile
@@ -39,13 +39,15 @@ RUN chmod 755 /var/log/isamples
 ARG ISB_SITEMAP_PREFIX=https://mars.cyverse.org
 ARG ANALYTICS_DOMAIN=isamples.org
 RUN echo "ISB_SITEMAP_PREFIX IS $ISB_SITEMAP_PREFIX ANALYTICS_DOMAIN is $ANALYTICS_DOMAIN"
+ARG DATACITE_PREFIX="123456"
+RUN echo "ISB_SITEMAP_PREFIX IS $ISB_SITEMAP_PREFIX ANALYTICS_DOMAIN is $ANALYTICS_DOMAIN DATACITE_PREFIX IS $DATACITE_PREFIX"
 COPY ./isamples_webui/asset-manifest.json /app/isb_web/ui/
 COPY ./isamples_webui/cesium /app/isb_web/ui/cesium
 COPY ./isamples_webui/index.html /app/isb_web/ui/
 COPY ./isamples_webui/manifest.json /app/isb_web/ui/
 COPY ./isamples_webui/robots.txt /app/isb_web/ui/
 COPY ./isamples_webui/static /app/isb_web/ui/static
-RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
+RUN echo "const _solr_base = \"$ISB_SITEMAP_PREFIX/thing/\";\n\nconst config = {\n  \"solr_url\": _solr_base + \"select\",\n  \"solr_stream\": _solr_base + \"stream\",\n  \"analytics_src\": \"https://metrics.isample.xyz/js/plausible.js\",\n  \"analytics_domain\": \"$ANALYTICS_DOMAIN\"\n, \"datacite_prefix\": \"$DATACITE_PREFIX\"\n};\n\nwindow.config = config;" | tee /app/isb_web/ui/config.js
 
 # Install nodejs in the container
 USER root


### PR DESCRIPTION
New config field that contains the datacite prefix:

```
cat /app/isb_web/ui/config.js 
const _solr_base = "https://mars.cyverse.org/isamples_central/thing/";

const config = {
  "solr_url": _solr_base + "select",
  "solr_stream": _solr_base + "stream",
  "analytics_src": "https://metrics.isample.xyz/js/plausible.js",
  "analytics_domain": "isamples.org",
  "datacite_prefix": "10.82273"
};

window.config = config;
```