### PR TITLE
Integrate prometheus into our Docker stack, start it up on port 9090

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,32 @@ services:
             - "8989"
         depends_on:
             - solr
+
+    node_exporter:
+        image: quay.io/prometheus/node-exporter:latest
+        container_name: node_exporter
+        command:
+            - '--path.rootfs=/host'
+        network_mode: host
+        pid: host
+        restart: unless-stopped
+        volumes:
+            - '/:/host:ro,rslave'
+        expose:
+            - "9100"
+
+    prometheus:
+        build: ./prometheus
+        ports:
+            - "9090:9090"
+        depends_on:
+            - solr_exporter
+            - db_exporter
+        volumes:
+            - prometheus_data:/prometheus
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+
     isamples_inabox:
         build:
             context: ./isb/
@@ -87,6 +113,8 @@ volumes:
         name: ${SITEMAPS_VOLUME_NAME}
     metadata_models:
         name: metadata_models
+    prometheus_data:
+        name: prometheus_data
         
 secrets:
     orcid_client_id:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,17 +11,36 @@ services:
             - pg_data:/var/lib/postgresql/data
         ports:
             - "${PG_PORT}:5432"
-        
+    db_exporter:
+        image: quay.io/prometheuscommunity/postgres-exporter
+        environment:
+            - DATA_SOURCE_NAME=postgresql://isb_writer:isamplesinabox@db:5432/postgres?sslmode=disable
+        expose:
+            - "9187"
+        depends_on:
+            - db
+
     solr:
         build: ./solr/
         volumes:
             - solr_data:/var/solr
         ports:
-            - "${SOLR_PORT}:8983"            
+            - "${SOLR_PORT}:8983"
+        expose:
+            - "9983"
         command: solr -f -cloud
         environment:
             - SOLR_HEAP=8192m
-        
+
+    solr_exporter:
+        build: ./solr/
+        command: solr-exporter
+        environment:
+            - ZK_HOST=solr:9983
+        expose:
+            - "8989"
+        depends_on:
+            - solr
     isamples_inabox:
         build:
             context: ./isb/
@@ -32,7 +51,7 @@ services:
                 ANALYTICS_DOMAIN: ${ANALYTICS_DOMAIN}
                 DATACITE_PREFIX: ${DATACITE_PREFIX}
                 DATACITE_PUBLISHER: ${DATACITE_PUBLISHER}
-                
+
         ports:
             # In the Docker network, start on 8000 and map that to the external port specified in the environment file
             - "${ISB_PORT}:8000"

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -34,3 +34,9 @@ scrape_configs:
   - job_name: 'solr-exporter'
     static_configs:
       - targets: ['solr_exporter:8989']
+      
+  - job_name: 'isb-exporter'
+    # scrape the iSB metrics once a day
+    scrape_interval: 86400s
+    static_configs:
+      - targets: ['isamples_inabox:8000']      

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,36 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+rule_files:
+  - 'prometheus.rules.yml'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name:       'node'
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:9100']
+
+  - job_name: 'postgresql-exporter'
+    static_configs:
+      - targets: ['db_exporter:9187']
+
+  - job_name: 'solr-exporter'
+    static_configs:
+      - targets: ['solr_exporter:8989']

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
 FROM solr:latest
 COPY ./jts-core-1.15.0.jar /opt/solr/server/solr-webapp/webapp/WEB-INF/lib/
-# uncomment this if we want to run a solr replication cluster with local zookeeper
-# COPY ./zoo.cfg /opt/solr/server/solr/zoo.cfg
+# this exposes the embedded zookeeper on the Docker network, so other services can talk to it (like the prometheus exporter)
+COPY ./zoo.cfg /opt/solr/server/solr/zoo.cfg


### PR DESCRIPTION
This PR integrates prometheus into our Docker Compose stack and runs it on port 9090.  It also starts the solr, postgresql, and node exporters and configure prometheus to scrape them.