### PR TITLE
Small changes based on observing prometheus deployed in a production-like environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,13 @@ services:
         command: solr -f -cloud
         environment:
             - SOLR_HEAP=8192m
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sf http://localhost:8983/solr/isb_core_records/admin/ping?wt=json | grep -i \"ok\" || exit 1"]
+            start_period: 15s
+            interval: 10s
+            timeout: 5s
+            retries: 3
+
 
     solr_exporter:
         build: ./solr/
@@ -40,7 +47,8 @@ services:
         expose:
             - "8989"
         depends_on:
-            - solr
+            solr:
+                condition: service_healthy
 
     node_exporter:
         image: quay.io/prometheus/node-exporter:latest
@@ -62,6 +70,7 @@ services:
         depends_on:
             - solr_exporter
             - db_exporter
+            - isamples_inabox
         volumes:
             - prometheus_data:/prometheus
         extra_hosts:
@@ -101,7 +110,8 @@ services:
         build: ./isb/
         depends_on:
             - isamples_inabox
-            - solr
+            solr:
+                condition: service_healthy
         command: python solr_schema_init/create_isb_core_schema.py    
     
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,8 +110,7 @@ services:
         build: ./isb/
         depends_on:
             - isamples_inabox
-            solr:
-                condition: service_healthy
+            - solr
         command: python solr_schema_init/create_isb_core_schema.py    
     
 volumes:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -37,6 +37,6 @@ scrape_configs:
       
   - job_name: 'isb-exporter'
     # scrape the iSB metrics once a day
-    scrape_interval: 86400s
+    scrape_interval: 60s
     static_configs:
       - targets: ['isamples_inabox:8000']      


### PR DESCRIPTION
Had a number of problems when we deployed this in AWS.  The biggest one is that the `solr-exporter` seemed to run too soon and prevent the solr instance from coming up cleanly.  Work around this by introducing a Docker health check.