### PR TITLE
Bump postgresql shm to 1g to allow vacuum

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
     db:
         image: postgres
-        shm_size: 128M
+        shm_size: 1g
         environment:
             - POSTGRES_PASSWORD=isamplesinabox
             - POSTGRES_USER=isb_writer


### PR DESCRIPTION
In an exploration of our postgresql performance problems, @datadavev found that the postgresql vacuum wasn't working properly.  When he changes the postgresql `shm_size` from 128M to 1g, things worked as expected.  The performance improvements were quite astounding.  We went from this performance before:

```
  # reqs      # fails |    Avg     Min     Max    Med |
|-------|-------------|-------|-------|-------|-------|
       7     0(0.00%) |   2773    2713    2955   2800 |
       4     0(0.00%) |   1251    1220    1331   1220 |
       6     0(0.00%) |   2364    2317    2401   2400 |
       4     0(0.00%) |     98      94     101     98 |
|-------|-------------|-------|-------|-------|-------|
      21     0(0.00%) |   1857      94    2955   2400 |
```

to this after running a manual `vacuum`:

```
  # reqs      # fails |    Avg     Min     Max    Med |
|-------|-------------|-------|-------|-------|-------|
      18     0(0.00%) |    709     627     825    720 |
      18     0(0.00%) |    385     315     432    400 |
      26     0(0.00%) |    272     241     310    260 |
      22     0(0.00%) |    118      93     313    100 |
|-------|-------------|-------|-------|-------|-------|
      84     0(0.00%) |    349      93     825    310 |
```